### PR TITLE
fix: add analyzer for Aggregate-derived class should be partial

### DIFF
--- a/.junie/guidelines.md
+++ b/.junie/guidelines.md
@@ -5,11 +5,11 @@ These rules describe how to write tests in this repository. They are intentional
 - Test framework: xUnit
 - Mocking: NSubstitute (when needed)
 - Target framework: net9.0 (match the project under test)
-- Project name for Results library tests: ErikLieben.FA.Results.Tests
+- Project name for Results library tests: ErikLieben.FA.ES
 
 ## File and type naming
 - Place tests for a type in a separate file named `{TypeName}Tests.cs` (e.g., `ResultTests.cs`).
-- Namespace should mirror the project, e.g., `namespace ErikLieben.FA.Results.Tests;`.
+- Namespace should mirror the project, e.g., `namespace ErikLieben.FA.ES;`.
 - Use one top-level public test class per SUT type: `public class {TypeName}Tests { ... }`.
 - When testing a specific method on the SUT, create an inner class with the method name inside the outer test class.
   - Example: `public class ResultTests { public class Map { /* tests for Result<T>.Map */ } }`.
@@ -47,7 +47,7 @@ using System;
 using ErikLieben.FA.Results;
 using Xunit;
 
-namespace ErikLieben.FA.Results.Tests;
+namespace ErikLieben.FA.ES;
 
 public class ResultTests
 {
@@ -91,7 +91,7 @@ using System;
 using ErikLieben.FA.Results;
 using Xunit;
 
-namespace ErikLieben.FA.Results.Tests;
+namespace ErikLieben.FA.ES;
 
 public class ResultOfTTests
 {

--- a/README.md
+++ b/README.md
@@ -40,10 +40,10 @@ ErikLieben.FA.ES is an event sourcing toolkit/framework designed to be:
 
 ## Install
 
-Install the CLI tool:
+Install the CLI tool (locally):
 ```bash
 dotnet new tool-manifest
-dotnet tool install --global ErikLieben.FA.ES.CLI
+dotnet tool install ErikLieben.FA.ES.CLI --local
 ```
 
 Add the NuGet package to your domain class library:

--- a/release.config.js
+++ b/release.config.js
@@ -10,13 +10,22 @@ module.exports = {
       {
         preset: 'conventionalcommits',
         releaseRules: [
+          // Only these types trigger releases
           {breaking: true, release: 'major'},
-          {type: 'docs', scope:'README', release: 'patch'},
-          {type: 'perf', release: 'patch'},
-          {type: 'fix', release: 'patch'},
-          {type: 'deps', release: 'patch'},
-          {type: "chore", release: false },
           {type: 'feat', release: 'minor'},
+          {type: 'fix', release: 'patch'},
+          // Manual release trigger - use when you want to release accumulated changes
+          {type: 'release', release: 'patch'},
+          // Block all other types (including deps from Renovate)
+          {type: 'deps', release: false},
+          {type: 'chore', release: false},
+          {type: 'docs', release: false},
+          {type: 'perf', release: false},
+          {type: 'style', release: false},
+          {type: 'test', release: false},
+          {type: 'refactor', release: false},
+          {type: 'ci', release: false},
+          {type: 'build', release: false}
         ],
         parserOpts: {
           noteKeywords: [
@@ -70,7 +79,18 @@ module.exports = {
             scope: 'deps',
             section: '⬆️ Dependency updates',
             hidden: false
-          }
+          },
+          {
+            type: 'chore',
+            scope: 'test-deps',
+            section: '🧪 Test dependency updates',
+            hidden: true  // Hide test dependencies from release notes
+          },
+          {
+            type: 'release',
+            section: '🚀 Release',
+            hidden: false
+          },
         ]
       },
       parserOpts: {

--- a/src/ErikLieben.FA.ES.Analyzers/Analyzers.md
+++ b/src/ErikLieben.FA.ES.Analyzers/Analyzers.md
@@ -1,8 +1,7 @@
-﻿## Unshipped
-
-### New Rules
+﻿# Analyzers
 
 Rule ID | Category | Severity | Notes
 ----- | ----- | ----- | -----
 FAES0001 | Usage | Warning | Prefer Fold over When (WhenUsageAnalyzer)
 FAES0002 | Usage | Warning | Event appended but not applied to active state (AppendWithoutApplyAnalyzer)
+FAES0003 | Usage | Warning | Aggregate-derived class should be partial (NonPartialAggregateAnalyzer)

--- a/src/ErikLieben.FA.ES.Analyzers/ErikLieben.FA.ES.Analyzers.csproj
+++ b/src/ErikLieben.FA.ES.Analyzers/ErikLieben.FA.ES.Analyzers.csproj
@@ -46,4 +46,7 @@
     <ItemGroup>
         <None Include="$(OutputPath)$(AssemblyName).dll" Pack="true" PackagePath="analyzers/dotnet/cs" />
     </ItemGroup>
+    <ItemGroup>
+      <AdditionalFiles Remove="AnalyzerReleases.Shipped.md" />
+    </ItemGroup>
 </Project>

--- a/src/ErikLieben.FA.ES.Analyzers/NonPartialAggregateAnalyzer.cs
+++ b/src/ErikLieben.FA.ES.Analyzers/NonPartialAggregateAnalyzer.cs
@@ -1,0 +1,58 @@
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace ErikLieben.FA.ES.Analyzers;
+
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public class NonPartialAggregateAnalyzer : DiagnosticAnalyzer
+{
+    public const string DiagnosticId = "FAES0003";
+
+    private static readonly LocalizableString Title = "Aggregate-derived class should be partial";
+    private static readonly LocalizableString MessageFormat = "Class '{0}' inherits from Aggregate and should be declared partial to allow CLI code generation";
+    private static readonly LocalizableString Description = "Classes that inherit from ErikLieben.FA.ES.Processors.Aggregate must be declared partial so that the CLI tool can extend them.";
+    private const string Category = "Usage";
+
+    private static readonly DiagnosticDescriptor Rule = new DiagnosticDescriptor(
+        DiagnosticId, Title, MessageFormat, Category, DiagnosticSeverity.Warning,
+        isEnabledByDefault: true, description: Description);
+
+    private const string AggregateFullName = "ErikLieben.FA.ES.Processors.Aggregate";
+
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
+
+    public override void Initialize(AnalysisContext context)
+    {
+        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+        context.EnableConcurrentExecution();
+        context.RegisterSyntaxNodeAction(AnalyzeClassDeclaration, SyntaxKind.ClassDeclaration);
+    }
+
+    private static void AnalyzeClassDeclaration(SyntaxNodeAnalysisContext context)
+    {
+        if (context.Node is not ClassDeclarationSyntax classDecl)
+            return;
+
+        // Only consider non-partial classes
+        if (classDecl.Modifiers.Any(SyntaxKind.PartialKeyword))
+            return;
+
+        // Resolve the symbol and check base types
+        var symbol = context.SemanticModel.GetDeclaredSymbol(classDecl);
+        if (symbol is null)
+            return;
+
+        for (var type = symbol.BaseType; type != null; type = type.BaseType)
+        {
+            if (type.ToDisplayString() == AggregateFullName)
+            {
+                var diagnostic = Diagnostic.Create(Rule, classDecl.Identifier.GetLocation(), symbol.Name);
+                context.ReportDiagnostic(diagnostic);
+                break;
+            }
+        }
+    }
+}

--- a/test/ErikLieben.FA.ES.Analyzers.Tests/NonPartialAggregateAnalyzerTests.cs
+++ b/test/ErikLieben.FA.ES.Analyzers.Tests/NonPartialAggregateAnalyzerTests.cs
@@ -1,0 +1,102 @@
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Testing;
+using Microsoft.CodeAnalysis.CSharp.Testing.XUnit;
+using Microsoft.CodeAnalysis.Testing;
+using Microsoft.CodeAnalysis.Testing.Verifiers;
+
+namespace ErikLieben.FA.ES.Analyzers.Tests;
+
+public class NonPartialAggregateAnalyzerTests
+{
+    private const string CommonStubs = @"
+namespace ErikLieben.FA.ES
+{
+}
+
+namespace ErikLieben.FA.ES.Processors
+{
+    public abstract class Aggregate { }
+}
+";
+
+    [Fact]
+    public async Task Should_report_when_class_inherits_aggregate_and_is_not_partial()
+    {
+        // Arrange
+        var test = CommonStubs + @"
+namespace Test
+{
+    using ErikLieben.FA.ES.Processors;
+
+    public class {|#0:MyAgg|} : Aggregate
+    {
+    }
+}
+";
+        var expected = new DiagnosticResult(NonPartialAggregateAnalyzer.DiagnosticId, DiagnosticSeverity.Warning)
+            .WithLocation(0)
+            .WithMessage("Class 'MyAgg' inherits from Aggregate and should be declared partial to allow CLI code generation");
+
+        // Act/Assert
+        await new CSharpAnalyzerTest<NonPartialAggregateAnalyzer, XUnitVerifier>
+        {
+            ReferenceAssemblies = ReferenceAssemblies.Net.Net90,
+            TestCode = test,
+            ExpectedDiagnostics = { expected }
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task Should_not_report_when_class_is_partial()
+    {
+        // Arrange
+        var test = CommonStubs + @"
+namespace Test
+{
+    using ErikLieben.FA.ES.Processors;
+
+    public partial class MyAgg : Aggregate
+    {
+    }
+}
+";
+
+        // Act/Assert
+        await new CSharpAnalyzerTest<NonPartialAggregateAnalyzer, XUnitVerifier>
+        {
+            ReferenceAssemblies = ReferenceAssemblies.Net.Net90,
+            TestCode = test
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task Should_report_also_for_indirect_inheritance()
+    {
+        // Arrange
+        var test = CommonStubs + @"
+namespace Test
+{
+    using ErikLieben.FA.ES.Processors;
+
+    public abstract class {|#1:BaseAgg|} : Aggregate { }
+
+    public class {|#0:MyAgg|} : BaseAgg
+    {
+    }
+}
+";
+        var expected1 = new DiagnosticResult(NonPartialAggregateAnalyzer.DiagnosticId, DiagnosticSeverity.Warning)
+            .WithLocation(0);
+        var expected2 = new DiagnosticResult(NonPartialAggregateAnalyzer.DiagnosticId, DiagnosticSeverity.Warning)
+            .WithLocation(1);
+
+        // Act/Assert
+        await new CSharpAnalyzerTest<NonPartialAggregateAnalyzer, XUnitVerifier>
+        {
+            ReferenceAssemblies = ReferenceAssemblies.Net.Net90,
+            TestCode = test,
+            ExpectedDiagnostics = { expected1, expected2 }
+        }.RunAsync();
+    }
+}


### PR DESCRIPTION
An analyzer to detect 

```csharp
public class Account(IEventStream stream) : Aggregate(stream);
```
it should be:

```csharp
public partial class Account(IEventStream stream) : Aggregate(stream);
```
Show warning: "Class 'Account' inherits from Aggregate and should be declared partial to allow CLI code generation